### PR TITLE
Added tabbing accessibility handlers

### DIFF
--- a/src/components/modal.js
+++ b/src/components/modal.js
@@ -1,16 +1,61 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import PropTypes from 'prop-types';
 
 function Modal (props) {
   const { displayModal, closeModalFunction, closeIcon, headerContent, mainContent, footerContent } = props;
+  const selectablesQuery = 'a[href], area[href], input:not([disabled]), select:not([disabled]), textarea:not([disabled]), button:not([disabled]),[role="button"], [tabindex="0"]';
 
+  useEffect(function () {
+    document.addEventListener('keydown', function (e) {
+      const modalContainer = document.querySelector('.modal-container');
+      if (modalContainer == null) {
+        return;
+      }
+      const focusableEls = Array.prototype.slice.call(modalContainer.querySelectorAll(selectablesQuery));
+      switch (e.keyCode) {
+        // Tab
+        case 9:
+        // If there's only one element in the modal that's focusable, disable tabbing  
+        if (modalContainer.querySelectorAll(selectablesQuery).length === 1) {
+            e.preventDefault();
+            break;
+          }
+          // Tabbing backwards
+          if (e.shiftKey) {
+            if (document.activeElement === focusableEls[0]) {
+              e.preventDefault();
+              focusableEls[0].focus();
+            }
+          }else {
+            // Wrap around to the beginning if we've hit the last focusable element in the modal
+            if (document.activeElement == focusableEls[focusableEls.length - 1]) {
+              e.preventDefault();
+              focusableEls[0].focus();
+            }
+          }
+          break;
+        default:
+          break;
+      }
+    });
+  }, []);
+  
+  
+  // Focus on a modal when it's displayed
+  useEffect(function () {
+    if (displayModal) {
+      const modalContainer = document.querySelector('.modal-container'),
+            focusableEls = Array.prototype.slice.call(modalContainer.querySelectorAll(selectablesQuery));
+      focusableEls[0].focus();
+    }
+  });
   if (displayModal) {
     return (
       <React.Fragment>
         <div className={'modal-container'} role='dialog' aria-labelledby='header' aria-describedby='modal-content'>
           <header>
             <h2 id='header'>{headerContent}</h2>
-            {closeIcon ? <img className='close-modal-button' src={closeIcon} onClick={closeModalFunction} tabIndex='1' alt='close icon' /> : null}
+            {closeIcon ? <img className='close-modal-button' src={closeIcon} onClick={closeModalFunction} role='button' tabIndex='1' alt='close icon' /> : null}
           </header>
           <main id='modal-content' className='modal-content'>{mainContent}</main>
           <footer className='modal-footer'>{footerContent}</footer>


### PR DESCRIPTION
Added some lifecycle methods to both register keydown event handlers on initial component mounting, as well as to focus on the first focusable element in the modal when it's opened.

Tabbing now does the following:
* When the modal is open, tab cycles through focusable elements in the modal. 
* If tabbing backwards on the first element and the modal is active, nothing happens.
* If tabbing forwards on the last element and the modal is active, focus wraps around to the first element
* When first opening the modal, the first focusable element is focused.